### PR TITLE
Fix failing request tests

### DIFF
--- a/test/top-to-bottom/simple-requests-test.js
+++ b/test/top-to-bottom/simple-requests-test.js
@@ -1,8 +1,9 @@
 var assert = require('assert');
 var expectRejection = require('./../helpers').expectRejection;
+var testApp = require('./../test-app/test-app');
 
 describe("Good guy HTTP", function() {
-  var app = require('./../test-app/test-app')();
+  var app = testApp();
 
   var gghttp = require('../../')({
     maxRetries: 0,
@@ -62,7 +63,7 @@ describe("Good guy HTTP", function() {
   });
 
   it("should reject when connection fails", function(done) {
-    expectRejection(gghttp(app.url("http://127.0.0.1:1"))).then(function(err) {
+    expectRejection(gghttp(testApp("1").url("/"))).then(function(err) {
       assert.equal(err.code, "ECONNREFUSED");
       done();
     }).catch(done);

--- a/test/unit/promised-requests-test.js
+++ b/test/unit/promised-requests-test.js
@@ -2,9 +2,10 @@ var request = require('request');
 var assert = require('assert');
 var Promise = require('bluebird');
 var expectRejection = require('./../helpers').expectRejection;
+var testApp = require('./../test-app/test-app');
 
 describe("Promised requests", function() {
-  var app = require('./../test-app/test-app')();
+  var app = testApp();
   var req = require('../../lib/promised-request')(request.defaults({timeout: 500}), Promise);
 
   before(function(done) {
@@ -54,7 +55,7 @@ describe("Promised requests", function() {
   });
 
   it("should reject when connection fails", function(done) {
-    expectRejection(req(app.url("http://127.0.0.1:1"))).then(function(err) {
+    expectRejection(req(testApp(1).url("/"))).then(function(err) {
       assert.equal(err.code, "ECONNREFUSED");
       done();
     }).catch(done);


### PR DESCRIPTION
I tried running `npm test` without any changes, but had 2 failing tests. After some debugging, I noticed the requested URL was wrong:

```
{ [Error: HTTP error: status code 404]
  code: 'EHTTP',
  statusCode: 404,
  request: 'http://localhost:13515http://127.0.0.10:1',
```

I have no idea how this can work on travis.

Not sure you want to modify `getUrl` inside test-app.js or make a new testApp that overrides the port. Let me know if you want it solved in another way :)
