### PR TITLE
Upgrade request from 2.81.0 to 2.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@schibstedpl/circuit-breaker-js": "0.0.2",
     "clone": "2.1.1",
-    "request": "2.81.0",
+    "request": "2.87.0",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4"
   },


### PR DESCRIPTION
This removes 10 transitive dependencies that request@2.81.0 pulls in. These are fixed in 2.87.0.