### PR TITLE
fix(idempotent-override): do not omit idempotent from request overrides

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,8 +72,7 @@ var OUR_CONFIGURATION_PROPERTIES = [
   'usePromise',
   'requestLib',
   'logTiming',
-  'mockTimer',
-  'idempotent'
+  'mockTimer'
 ];
 
 var CONVENIENCE_METHODS = {


### PR DESCRIPTION
idempotent should not be in the OUR_CONFIGURATION_PROPERTIES as it is only read from the request object. Removing it enables users to add idempotent property to override behaviour for single requests.
Related issue: https://github.com/Schibsted-Tech-Polska/good-guy-http/issues/18