### PR TITLE
docs: add deprecated message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # good-guy-http
 
-[![Build Status](https://travis-ci.org/Schibsted-Tech-Polska/good-guy-http.svg?branch=master)](https://travis-ci.org/Schibsted-Tech-Polska/good-guy-http) [![Coverage Status](https://coveralls.io/repos/Schibsted-Tech-Polska/good-guy-http/badge.svg?branch=master)](https://coveralls.io/r/Schibsted-Tech-Polska/good-guy-http?branch=master) [![Dependency status](https://david-dm.org/Schibsted-Tech-Polska/good-guy-http.svg)](https://david-dm.org/Schibsted-Tech-Polska/good-guy-http)
+**!! THIS CODE IS NO LONGER MAINTAINED !!**
+
+---
 
 Good guy HTTP is an HTTP client library based on the [request][request] module, adding the following stuff on top:
 


### PR DESCRIPTION
Plan: add this message in the Readme, then archive the repo.
Npm package is already marked as deprecated https://www.npmjs.com/package/good-guy-http